### PR TITLE
Adding tests for registration endpoints, remvoing server startin from app.js. Gave registration correct response codes

### DIFF
--- a/JestTests/register.test.js
+++ b/JestTests/register.test.js
@@ -1,11 +1,65 @@
 const request = require('supertest');
 const app = require('../app');
 
+const random = () => {
+    return Math.floor(Math.random() * 10000)
+}
+
 describe('auth endpoints', () => {
-    it('Registering scenarios', async () => {
+    it('Register - valid username and password', async () => {
+        const randomNumber = random()
         const res = await request(app)
             .post('/auth/register')
-            .send({username: "testingUser", password: "testingpassword123!"})
-            .expect(200)
+            .send({username: 'testingUser' + randomNumber, password: 'testingpassword123!'})
+            .expect(201);
+            expect(res.statusCode).toBe(201);
+    })
+
+    it('Register - empty username with empty password', async () => {
+        const res = await request(app)
+        .post('/auth/register')
+        .send({username: '', password: ''})
+
+        expect(res.statusCode).toBe(400)
+        expect(res.body.error).toBe('Please enter a username and password')
+    })
+
+    it('Register - empty username with valid password', async () => {
+        const res = await request(app)
+        .post('/auth/register')
+        .send({username: '', password: 'testingpassword123!'})
+
+        expect(res.statusCode).toBe(400)
+        expect(res.body.error).toBe('Please enter a username')
+    })
+
+    it('Register - valid username with empty password', async () => {
+        const randomNumber = random()
+        const res = await request(app)
+        .post('/auth/register')
+        .send({username: 'testUser' + randomNumber, password: ''})
+
+        expect(res.statusCode).toBe(400)
+        expect(res.body.error).toBe('Please enter a password')
+    })
+
+    it('Register - valid username and invalid password (too short)', async () => {
+        const randomNumber = random()
+        const res = await request(app)
+            .post('/auth/register')
+            .send({username: 'testingUser' + randomNumber, password: 'badPass'})
+
+            expect(res.statusCode).toBe(400);
+            expect(res.body.error).toBe('Password must be at least 8 characters long')
+    })
+
+    it('Register - valid username and invalid password (corrent length but no number)', async () => {
+        const randoNumber = random()
+        const res = await request(app)
+            .post('/auth/register')
+            .send({username:'testingUser' + randoNumber, password:'testingpasswordNoNumber'})
+
+            expect(res.statusCode).toBe(400);
+            expect(res.body.error).toBe('Password must contain at least one number')
     })
 })

--- a/app.js
+++ b/app.js
@@ -45,9 +45,4 @@ const gameRoutes = require('./routes/game');
 app.use('/auth', authRoutes);
 app.use('/game', gameRoutes);
 
-
-app.listen(port, () => {
-    console.log(`Server running at http://localhost:${port}/`);
-});
-
 module.exports = app;

--- a/routes/authentication.js
+++ b/routes/authentication.js
@@ -15,8 +15,15 @@ router.post('/register', async(req, res) => {
     const uuidValue = uuid.v4();
     const {username, password} = req.body;
 
+    if(!username && !password){
+        return res.status(400).json({error: 'Please enter a username and password'})
+    } else if(!username && password) {
+        return res.status(400).json({error: 'Please enter a username'})
+    } else if(!password && username){
+        return res.status(400).json({error: 'Please enter a password'})
+    }
+
     try {
-        
         db.get(`SELECT * FROM accounts WHERE username = ?`, [username], (err, user) => {
             if (user) { return res.status(400).json({error: 'User already exists'})}
     
@@ -33,7 +40,7 @@ router.post('/register', async(req, res) => {
                 })
             db.run(`INSERT INTO users (user_id, username) VALUES (?, ?)`, [uuidValue, username], (err) => {
                 if (err) throw err;
-                    return res.status(200).json({ message: ` ${username} is registered`})
+                    return res.status(201).json({ message: ` ${username} is registered`})
             })
             })
         })
@@ -83,7 +90,7 @@ router.post('/login', async (req, res) => {
 
 router.post('/logout', (req, res) => {
     req.session.destroy((err) => {
-        res.status(200).json({ message: 'Logged out' });
+        res.status(204).json({ message: 'Logged out' });
         if(err) {
             return res.status(500).send('Error logging out');
         }

--- a/server.js
+++ b/server.js
@@ -1,4 +1,4 @@
-const app = require('./app'); // Adjust the path if necessary
+const app = require('./app'); 
 const port = process.env.PORT || 3000;
 
 app.listen(port, () => {

--- a/server.js
+++ b/server.js
@@ -1,0 +1,6 @@
+const app = require('./app'); // Adjust the path if necessary
+const port = process.env.PORT || 3000;
+
+app.listen(port, () => {
+    console.log(`Server running at http://localhost:${port}/`);
+});


### PR DESCRIPTION

- added 6 tests to the register.test.js file

- added responses for missing username and passwords in /auth/register to return 400 errors

- removed the starting of the server to an external file called server.js so tests weren't opening the server multiple times. Now supertest will mock the https requests based on the code in app.js (Of course if we wanted to actually run the server this can be added by adding a beforeAll to start the server)